### PR TITLE
Add special tag delimiter for container tags

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -28,6 +28,9 @@ RUN_TASK_NETWORK_CONFIGURATION=false
 RUN_TASK_WAIT_FOR_SUCCESS=false
 TASK_DEFINITION_TAGS=false
 COPY_TASK_DEFINITION_TAGS=false
+SPECIAL_TAG_DELIMITER='---'  # Used for special tags as a unique separator; anything after
+                             # this delimiter in the tag name will be preserved when replacing
+                             # the ECS task definition.
 
 function usage() {
     cat <<EOM
@@ -365,7 +368,7 @@ function createNewTaskDefJson() {
             | jq '.taskDefinition' )
     else
       DEF=$( echo "$taskDefinition" \
-            | sed -e "s|\(\"image\": *\".*:\)\(.*\)\"|\1${useImage}\"|g" \
+            | sed -e "s|\(\"image\": *\".*:\)\([^-]*\)\(${SPECIAL_TAG_DELIMITER}.*\)\?\"|\\1${useImage}\\3\"|g" \
             | jq '.taskDefinition' )
     fi
 


### PR DESCRIPTION
### Added
Allows specifying a specially delimited component of the Docker image tags that will be preserved through replacements of the ECS task definition images. Defaults to `---`. For example, a tag `latest---blah` will replace `latest` as expected but leave `---blah`. 

### Changed (non-breaking)
Yes

### Changed (BREAKING)
N/A

### Deprecated
N/A

### Removed
N/A

### Fixed
N/A 

### Security
N/A

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, etc.)
- [ ] Unit tests created or updated (see `test.bats` file)

### Release PR Checklist
- [ ] Update version number in `ecs-deploy` script
- [ ] Give the PR a title of `Release _._._ - Summary of change` (using whatever
      the new version number is, plus a succinct summary of what changed)
